### PR TITLE
Polish launch and picker windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ codex-build/
 *.key
 *.pvk
 *.snk
-TITAN Softwork Solutions.pfx
+RYFTENIUS.pfx
 
 # Website documentation is published from the website pipeline, not the
 # Community source repo.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Lib/Blackbird Disassembler"]
 path = Lib/Blackbird Disassembler
-url = https://github.com/TITAN-Softwork-Solutions/Blackbird-Disassembler
+url = https://github.com/RYFTENIUS/Blackbird-Disassembler

--- a/Blackbird.inf
+++ b/Blackbird.inf
@@ -50,7 +50,7 @@ HKR,"Instances\%BlackbirdInstanceName%","Altitude",0x00000000,%BlackbirdInstance
 HKR,"Instances\%BlackbirdInstanceName%","Flags",0x00010001,%BlackbirdInstanceFlags%
 
 [Strings]
-ManufacturerName = "TITAN Softwork Solutions"
+ManufacturerName = "RYFTENIUS"
 DiskName = "Blackbird Community Installation Disk"
 BLACKBIRD.SVCDESC = "Blackbird Community Driver"
 BlackbirdInstanceName = "Blackbird Default"

--- a/Client/analysis/App.xaml.cs
+++ b/Client/analysis/App.xaml.cs
@@ -24,7 +24,7 @@ namespace BlackbirdInterface
 
     public partial class App : Application
     {
-        private const string GettingStartedUrl = "https://titansoftwork.com/blackbird/intro";
+        private const string GettingStartedUrl = "https://ryftenius.com/blackbird/intro";
         private static Mutex? _singleInstanceMutex;
         internal static bool IsDarkTheme { get; private set; } = true;
         internal static UiThemeMode CurrentThemeMode { get; private set; } = UiThemeMode.Dark;

--- a/Client/analysis/Interop/BlackbirdNative.cs
+++ b/Client/analysis/Interop/BlackbirdNative.cs
@@ -222,6 +222,7 @@ namespace BlackbirdInterface
         internal const uint IpcEtwFamilyThreatIntel = 8;
         internal const uint IpcEtwFamilySocket = 9;
         internal const uint IpcEtwFamilyUserHook = 10;
+        internal const uint IpcEtwFamilyIpcIo = 11;
 
         internal const uint IpcEtwFlagHandleExecProtect = 0x00000001;
         internal const uint IpcEtwFlagHandleFromNtdll = 0x00000002;

--- a/Client/analysis/Settings/AnalystSettingsStore.cs
+++ b/Client/analysis/Settings/AnalystSettingsStore.cs
@@ -6,7 +6,7 @@ namespace BlackbirdInterface
 {
     internal static class AnalystSettingsStore
     {
-        private const string RootKeyPath = @"Software\TITAN Softwork Solutions\BK\Interface";
+        private const string RootKeyPath = @"Software\RYFTENIUS\BK\Interface";
         private const string ThemeValueName = "ThemeMode";
         private const string ShortcutKeyPath = RootKeyPath + @"\Shortcuts";
         private const string PreferencesKeyPath = RootKeyPath + @"\Preferences";

--- a/Client/analysis/Settings/SymbolSettingsStore.cs
+++ b/Client/analysis/Settings/SymbolSettingsStore.cs
@@ -5,7 +5,7 @@ namespace BlackbirdInterface
 {
     internal static class SymbolSettingsStore
     {
-        private const string RootKeyPath = @"Software\TITAN Softwork Solutions\BK\Interface";
+        private const string RootKeyPath = @"Software\RYFTENIUS\BK\Interface";
         private const string SymbolsKeyPath = RootKeyPath + @"\Symbols";
 
         internal static SymbolSettings LoadSymbolSettings()

--- a/Client/analysis/Themes/DarkTheme.xaml
+++ b/Client/analysis/Themes/DarkTheme.xaml
@@ -3,17 +3,17 @@
 
     <Color x:Key="WinBgColor">#FF0C0C0C</Color>
     <Color x:Key="WinPanelColor">#FF121212</Color>
-    <Color x:Key="WinHeaderColor">#FF181818</Color>
-    <Color x:Key="PaneBorderColor">#FF8A8A8A</Color>
-    <Color x:Key="WinBorderColor">#FF2B2B2B</Color>
-    <Color x:Key="WinSubtleBorderColor">#FF4E4E4E</Color>
+    <Color x:Key="WinHeaderColor">#FF141414</Color>
+    <Color x:Key="PaneBorderColor">#FF242424</Color>
+    <Color x:Key="WinBorderColor">#FF242424</Color>
+    <Color x:Key="WinSubtleBorderColor">#FF303030</Color>
     <Color x:Key="WinTextColor">#FFE2E2E2</Color>
     <Color x:Key="WinMutedTextColor">#FFB5B5B5</Color>
     <Color x:Key="WinAccentColor">#FF8E2020</Color>
     <Color x:Key="InputHoverBorderColor">#FFB3B3B3</Color>
-    <Color x:Key="CommandBarBackgroundColor">#FF0B0B0B</Color>
+    <Color x:Key="CommandBarBackgroundColor">#FF0C0C0C</Color>
     <Color x:Key="CommandBarPanelColor">#FF121212</Color>
-    <Color x:Key="CommandBarButtonColor">#FF1A1A1A</Color>
+    <Color x:Key="CommandBarButtonColor">#FF161616</Color>
     <Color x:Key="StatusConnectedColor">#FF59BA59</Color>
     <Color x:Key="StatusFailedColor">#FFE0A144</Color>
     <Color x:Key="StatusBarNeutralColor">#FF111111</Color>
@@ -175,8 +175,8 @@
     <Style TargetType="ToolTip">
         <Setter Property="Background" Value="{StaticResource WinPanelBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="6"/>
     </Style>
 
@@ -184,6 +184,20 @@
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}" Value="True">
+                <Setter Property="Foreground" Value="#FF111111"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsPressed, RelativeSource={RelativeSource AncestorType=Button}}" Value="True">
+                <Setter Property="Foreground" Value="#FF111111"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
+                <Setter Property="Foreground" Value="#FF111111"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsPressed, RelativeSource={RelativeSource AncestorType=ToggleButton}}" Value="True">
+                <Setter Property="Foreground" Value="#FF111111"/>
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="Label">
@@ -211,16 +225,19 @@
                             CornerRadius="0">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
                                           Margin="{TemplateBinding Padding}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-        <Setter Property="Background" Value="#FF242424"/>
-        <Setter Property="BorderBrush" Value="#FFB3B3B3"/>
+                            <Setter Property="Background" Value="#FFF4F4F4"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-        <Setter Property="Background" Value="#FF141414"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                            <Setter Property="Background" Value="#FFE3E3E3"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -284,15 +301,15 @@
     <Style TargetType="ProgressBar">
         <Setter Property="Background" Value="#FF101513"/>
         <Setter Property="Foreground" Value="#FF6FD3A8"/>
-        <Setter Property="BorderBrush" Value="#FF29443C"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
     </Style>
 
     <Style TargetType="ToggleButton">
         <Setter Property="Background" Value="{StaticResource WinHeaderBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="10,4"/>
         <Setter Property="Margin" Value="4,0"/>
         <Setter Property="MinWidth" Value="70"/>
@@ -306,16 +323,19 @@
                             CornerRadius="0">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
                                           Margin="{TemplateBinding Padding}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#FF242424"/>
-                            <Setter Property="BorderBrush" Value="#FFB3B3B3"/>
+                            <Setter Property="Background" Value="#FFF4F4F4"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="#FF141414"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                            <Setter Property="Background" Value="#FFE3E3E3"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
                             <Setter Property="Background" Value="#FF181818"/>
@@ -331,7 +351,7 @@
         <Style.Triggers>
             <Trigger Property="IsChecked" Value="True">
                 <Setter Property="Background" Value="#FF141414"/>
-                <Setter Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -341,7 +361,7 @@
         <Setter Property="MinHeight" Value="22"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Margin" Value="4,3,0,3"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="BorderBrush" Value="#00000000"/>
         <Setter Property="Background" Value="#00000000"/>
         <Setter Property="Template">
@@ -351,16 +371,20 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="0">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#33333333"/>
-                            <Setter Property="BorderBrush" Value="#88AAB2BC"/>
+                            <Setter Property="Background" Value="#FFF4F4F4"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="#66404040"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                            <Setter Property="Background" Value="#FFE3E3E3"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -398,7 +422,7 @@
     <Style x:Key="FilterInputStyle" TargetType="TextBox">
         <Setter Property="Background" Value="#FF151515"/>
         <Setter Property="Foreground" Value="{DynamicResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource WinBorderBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource WinSubtleBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="CaretBrush" Value="{DynamicResource WinTextBrush}"/>
         <Setter Property="SelectionBrush" Value="#66707070"/>
@@ -525,7 +549,7 @@
     <Style TargetType="TextBox">
         <Setter Property="Background" Value="#FF151515"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource WinSubtleBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="6,3"/>
         <Setter Property="Margin" Value="4,0"/>
@@ -653,7 +677,7 @@
         <Setter Property="Background" Value="#FF1B1B1B"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
         <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Padding" Value="8,5"/>
     </Style>
@@ -819,7 +843,7 @@
     <Style TargetType="Thumb">
         <Setter Property="Background" Value="#FF6E7781"/>
         <Setter Property="BorderBrush" Value="#FF9AA4AE"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Thumb">
@@ -1273,18 +1297,19 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
                         <ContentPresenter HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"/>
+                                          VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Chrome" Property="Background" Value="#FF2A2A2A"/>
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#FF3A3A3A"/>
-                            <Setter TargetName="Chrome" Property="BorderThickness" Value="1"/>
+                            <Setter TargetName="Chrome" Property="Background" Value="#FFF4F4F4"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="Transparent"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="Chrome" Property="Background" Value="#FF1D1D1D"/>
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
-                            <Setter TargetName="Chrome" Property="BorderThickness" Value="1"/>
+                            <Setter TargetName="Chrome" Property="Background" Value="#FFE3E3E3"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="Transparent"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -1292,9 +1317,8 @@
                                 <Condition Property="IsMouseOver" Value="True"/>
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Chrome" Property="Background" Value="#FFAA3A3A"/>
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#FFBC5454"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="Transparent"/>
                             <Setter Property="Foreground" Value="#FFF7EDED"/>
-                            <Setter TargetName="Chrome" Property="BorderThickness" Value="1"/>
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -1302,9 +1326,8 @@
                                 <Condition Property="IsPressed" Value="True"/>
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Chrome" Property="Background" Value="#FF912E2E"/>
-                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#FFBC5454"/>
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="Transparent"/>
                             <Setter Property="Foreground" Value="#FFF7EDED"/>
-                            <Setter TargetName="Chrome" Property="BorderThickness" Value="1"/>
                         </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -1318,7 +1341,7 @@
     <Style x:Key="SecondaryWindowSurfaceBorderStyle" TargetType="Border">
         <Setter Property="Background" Value="{StaticResource WinPanelBrush}"/>
         <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="8"/>
     </Style>
 
@@ -1332,7 +1355,7 @@
     <Style x:Key="SecondaryWindowFilterBarStyle" TargetType="Border">
         <Setter Property="Background" Value="{StaticResource WinPanelBrush}"/>
         <Setter Property="BorderBrush" Value="{StaticResource WinSubtleBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="8"/>
     </Style>
 

--- a/Client/analysis/Themes/LightTheme.xaml
+++ b/Client/analysis/Themes/LightTheme.xaml
@@ -4,9 +4,9 @@
     <Color x:Key="WinBgColor">#FFF5F3EF</Color>
     <Color x:Key="WinPanelColor">#FFFDFBF7</Color>
     <Color x:Key="WinHeaderColor">#FFEAE4DC</Color>
-    <Color x:Key="PaneBorderColor">#FFB8ADA2</Color>
-    <Color x:Key="WinBorderColor">#FFD0C5B9</Color>
-    <Color x:Key="WinSubtleBorderColor">#FFE1D8CF</Color>
+    <Color x:Key="PaneBorderColor">#FFE4DDD5</Color>
+    <Color x:Key="WinBorderColor">#FFE2DBD3</Color>
+    <Color x:Key="WinSubtleBorderColor">#FFE9E3DC</Color>
     <Color x:Key="WinTextColor">#FF1F1C18</Color>
     <Color x:Key="WinMutedTextColor">#FF6E655D</Color>
     <Color x:Key="WinAccentColor">#FF9A2F23</Color>
@@ -176,8 +176,8 @@
     <Style TargetType="ToolTip">
         <Setter Property="Background" Value="{StaticResource WinPanelBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="6"/>
     </Style>
 
@@ -199,16 +199,19 @@
                             CornerRadius="0">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
                                           Margin="{TemplateBinding Padding}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#FFF1E7DA"/>
-                            <Setter Property="BorderBrush" Value="#FF8F7F72"/>
+                            <Setter Property="Background" Value="#FFFFFFFF"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter Property="Background" Value="#FFE7DDD0"/>
-                            <Setter Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                            <Setter Property="Background" Value="#FFEFEFEF"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -272,15 +275,15 @@
     <Style TargetType="ProgressBar">
         <Setter Property="Background" Value="#FFEAE3D8"/>
         <Setter Property="Foreground" Value="#FF4C8E67"/>
-        <Setter Property="BorderBrush" Value="#FFC3B7A8"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
     </Style>
 
     <Style TargetType="ToggleButton">
         <Setter Property="Background" Value="{StaticResource WinHeaderBrush}"/>
         <Setter Property="Foreground" Value="{StaticResource WinTextBrush}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource WinBorderBrush}"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="10,4"/>
         <Setter Property="Margin" Value="4,0"/>
         <Setter Property="MinWidth" Value="70"/>
@@ -295,16 +298,18 @@
                             CornerRadius="0">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
                                           Margin="{TemplateBinding Padding}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="ToggleRoot" Property="Background" Value="#FFF1E7DA"/>
-                            <Setter TargetName="ToggleRoot" Property="BorderBrush" Value="#FF8F7F72"/>
+                            <Setter TargetName="ToggleRoot" Property="Background" Value="#FFFFFFFF"/>
+                            <Setter Property="Foreground" Value="#FF111111"/>
+                            <Setter TargetName="ToggleRoot" Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
                             <Setter TargetName="ToggleRoot" Property="Background" Value="#FFE7DDD0"/>
-                            <Setter TargetName="ToggleRoot" Property="BorderBrush" Value="{StaticResource WinAccentBrush}"/>
+                            <Setter TargetName="ToggleRoot" Property="BorderBrush" Value="Transparent"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>

--- a/Client/analysis/Theming/ThemedMessageBox.cs
+++ b/Client/analysis/Theming/ThemedMessageBox.cs
@@ -13,13 +13,18 @@ namespace BlackbirdInterface
                                             MessageBoxButton buttons = MessageBoxButton.OK,
                                             MessageBoxImage image = MessageBoxImage.None)
         {
+            bool isPreflightDialog = title.Contains("Preflight", StringComparison.OrdinalIgnoreCase);
             var dialog = new Window { Title = title,
-                                      Width = 432,
+                                      Width = isPreflightDialog ? 720 : 432,
                                       SizeToContent = SizeToContent.Height,
                                       MinWidth = 360,
                                       MinHeight = 0,
-                                      MaxWidth = 560,
-                                      MaxHeight = 320,
+                                      MaxWidth = isPreflightDialog
+                                                     ? Math.Min(SystemParameters.WorkArea.Width - 80, 900)
+                                                     : 560,
+                                      MaxHeight = isPreflightDialog
+                                                      ? Math.Min(SystemParameters.WorkArea.Height - 80, 720)
+                                                      : 320,
                                       WindowStartupLocation = owner == null ? WindowStartupLocation.CenterScreen
                                                                             : WindowStartupLocation.CenterOwner,
                                       Owner = owner,
@@ -34,8 +39,8 @@ namespace BlackbirdInterface
             WindowThemeHelper.ApplyTitleBarTheme(dialog, App.IsDarkTheme);
 
             var root = new Border { Background = dialog.Background,
-                                    BorderBrush = GetBrush("WinBorderBrush", Color.FromRgb(0x2B, 0x2B, 0x2B)),
-                                    BorderThickness = new Thickness(1) };
+                                    BorderBrush = Brushes.Transparent,
+                                    BorderThickness = new Thickness(0) };
 
             var layout = new Grid();
             layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
@@ -64,11 +69,17 @@ namespace BlackbirdInterface
 
             var messageBlock =
                 new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap,
+                                MaxWidth = isPreflightDialog ? 640 : double.PositiveInfinity,
                                 VerticalAlignment = VerticalAlignment.Top, Margin = new Thickness(0, 1, 0, 0),
                                 Foreground = GetBrush("MessageBoxMutedTextBrush", Color.FromRgb(0xB0, 0xB0, 0xB0)) };
 
             var messageScroll =
-                new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                new ScrollViewer { MaxHeight = isPreflightDialog
+                                                    ? Math.Max(260, SystemParameters.WorkArea.Height - 240)
+                                                    : 150,
+                                   VerticalScrollBarVisibility = isPreflightDialog
+                                                                     ? ScrollBarVisibility.Disabled
+                                                                     : ScrollBarVisibility.Auto,
                                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                                    CanContentScroll = false, Content = messageBlock };
             Grid.SetColumn(messageScroll, 1);
@@ -157,8 +168,8 @@ namespace BlackbirdInterface
             WindowThemeHelper.ApplyTitleBarTheme(toast, App.IsDarkTheme);
 
             var shell = new Border { Background = toast.Background,
-                                     BorderBrush = GetBrush("WinBorderBrush", Color.FromRgb(0x2B, 0x2B, 0x2B)),
-                                     BorderThickness = new Thickness(1) };
+                                     BorderBrush = Brushes.Transparent,
+                                     BorderThickness = new Thickness(0) };
 
             var layout = new Grid();
             layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
@@ -228,8 +239,8 @@ namespace BlackbirdInterface
         {
             var border =
                 new Border { Background = GetBrush("WinHeaderBrush", Color.FromRgb(0x1B, 0x1B, 0x1B)),
-                             BorderBrush = GetBrush("WinBorderBrush", Color.FromRgb(0x2B, 0x2B, 0x2B)),
-                             BorderThickness = new Thickness(0, 0, 0, 1), Padding = new Thickness(10, 6, 6, 6) };
+                             BorderBrush = Brushes.Transparent,
+                             BorderThickness = new Thickness(0), Padding = new Thickness(10, 6, 6, 6) };
 
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -304,16 +315,14 @@ namespace BlackbirdInterface
             var over = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
             over.Setters.Add(
                 new Setter(Control.BackgroundProperty, new SolidColorBrush(Color.FromRgb(0xAA, 0x3A, 0x3A))));
-            over.Setters.Add(
-                new Setter(Control.BorderBrushProperty, new SolidColorBrush(Color.FromRgb(0xBC, 0x54, 0x54))));
-            over.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(1)));
+            over.Setters.Add(new Setter(Control.BorderBrushProperty, Brushes.Transparent));
+            over.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0)));
 
             var pressed = new Trigger { Property = ButtonBase.IsPressedProperty, Value = true };
             pressed.Setters.Add(
                 new Setter(Control.BackgroundProperty, new SolidColorBrush(Color.FromRgb(0x91, 0x2E, 0x2E))));
-            pressed.Setters.Add(
-                new Setter(Control.BorderBrushProperty, new SolidColorBrush(Color.FromRgb(0xBC, 0x54, 0x54))));
-            pressed.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(1)));
+            pressed.Setters.Add(new Setter(Control.BorderBrushProperty, Brushes.Transparent));
+            pressed.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0)));
 
             template.Triggers.Add(over);
             template.Triggers.Add(pressed);
@@ -376,10 +385,43 @@ namespace BlackbirdInterface
                 new Setter(Control.ForegroundProperty, new SolidColorBrush(Color.FromRgb(0xE6, 0xE6, 0xE6))));
             style.Setters.Add(
                 new Setter(Control.BorderBrushProperty, new SolidColorBrush(Color.FromRgb(0x2B, 0x2B, 0x2B))));
-            style.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(1)));
+            style.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0)));
             style.Setters.Add(new Setter(Control.PaddingProperty, new Thickness(10, 4, 10, 4)));
             style.Setters.Add(new Setter(FrameworkElement.MinWidthProperty, 76d));
             style.Setters.Add(new Setter(FrameworkElement.MinHeightProperty, 24d));
+
+            var template = new ControlTemplate(typeof(Button));
+            var border = new FrameworkElementFactory(typeof(Border));
+            border.SetValue(Border.BackgroundProperty, new TemplateBindingExtension(Control.BackgroundProperty));
+            border.SetValue(Border.BorderBrushProperty, new TemplateBindingExtension(Control.BorderBrushProperty));
+            border.SetValue(Border.BorderThicknessProperty,
+                            new TemplateBindingExtension(Control.BorderThicknessProperty));
+
+            var presenter = new FrameworkElementFactory(typeof(ContentPresenter));
+            presenter.SetValue(FrameworkElement.HorizontalAlignmentProperty, HorizontalAlignment.Center);
+            presenter.SetValue(FrameworkElement.VerticalAlignmentProperty, VerticalAlignment.Center);
+            presenter.SetValue(FrameworkElement.MarginProperty, new TemplateBindingExtension(Control.PaddingProperty));
+            presenter.SetValue(System.Windows.Documents.TextElement.ForegroundProperty,
+                               new TemplateBindingExtension(Control.ForegroundProperty));
+            border.AppendChild(presenter);
+            template.VisualTree = border;
+
+            var over = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            over.Setters.Add(
+                new Setter(Control.BackgroundProperty, new SolidColorBrush(Color.FromRgb(0xF4, 0xF4, 0xF4))));
+            over.Setters.Add(new Setter(Control.ForegroundProperty, new SolidColorBrush(Color.FromRgb(0x11, 0x11, 0x11))));
+            over.Setters.Add(new Setter(Control.BorderBrushProperty, Brushes.Transparent));
+
+            var pressed = new Trigger { Property = ButtonBase.IsPressedProperty, Value = true };
+            pressed.Setters.Add(
+                new Setter(Control.BackgroundProperty, new SolidColorBrush(Color.FromRgb(0xE3, 0xE3, 0xE3))));
+            pressed.Setters.Add(
+                new Setter(Control.ForegroundProperty, new SolidColorBrush(Color.FromRgb(0x11, 0x11, 0x11))));
+            pressed.Setters.Add(new Setter(Control.BorderBrushProperty, Brushes.Transparent));
+
+            template.Triggers.Add(over);
+            template.Triggers.Add(pressed);
+            style.Setters.Add(new Setter(Control.TemplateProperty, template));
             return style;
         }
     }

--- a/Client/analysis/Windows/DiagnosticsWindow.xaml
+++ b/Client/analysis/Windows/DiagnosticsWindow.xaml
@@ -74,22 +74,22 @@
         </DataTemplate>
 
         <Style x:Key="BoardColumnBorderStyle" TargetType="Border">
-            <Setter Property="BorderBrush" Value="{DynamicResource WinBorderBrush}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Background" Value="#FF101010"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Background" Value="{DynamicResource WinPanelBrush}"/>
             <Setter Property="Padding" Value="0"/>
         </Style>
 
         <Style x:Key="BoardColumnHeaderStyle" TargetType="Border">
             <Setter Property="Background" Value="{DynamicResource WinHeaderBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource WinSubtleBorderBrush}"/>
-            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="12,10"/>
         </Style>
 
         <Style x:Key="FeedRichTextBoxStyle" TargetType="RichTextBox">
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#FF101010"/>
+            <Setter Property="Background" Value="{DynamicResource WinPanelBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource WinTextBrush}"/>
             <Setter Property="Padding" Value="12"/>
             <Setter Property="FontFamily" Value="{DynamicResource AppMonoFontFamily}"/>
@@ -108,9 +108,9 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0"
-                BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                BorderThickness="0,0,0,1"
-                Background="{DynamicResource WinHeaderBrush}"
+                BorderBrush="Transparent"
+                BorderThickness="0"
+                Background="{DynamicResource WinBgBrush}"
                 Padding="12,8"
                 Margin="0,0,0,12"
                 MouseLeftButtonDown="Root_MouseLeftButtonDown">
@@ -123,8 +123,8 @@
                                FontWeight="SemiBold"/>
                     <Border Margin="12,0,0,0"
                             Padding="10,3"
-                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                            BorderThickness="1"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
                             Background="{DynamicResource WinPanelBrush}">
                         <TextBlock x:Name="TargetBlock"
                                    VerticalAlignment="Center"
@@ -263,6 +263,10 @@
                                 <RichTextBox x:Name="ExceptionsFeedBox"
                                              Style="{StaticResource FeedRichTextBoxStyle}"/>
                             </TabItem>
+                            <TabItem Header="SR71 Map">
+                                <RichTextBox x:Name="SelfMapFeedBox"
+                                             Style="{StaticResource FeedRichTextBoxStyle}"/>
+                            </TabItem>
                             <TabItem Header="Architecture">
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                                               HorizontalScrollBarVisibility="Disabled">
@@ -351,11 +355,11 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
-                                    <Border Grid.Row="0"
-                                            Padding="10,6"
-                                            Background="{DynamicResource WinHeaderBrush}"
-                                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                                            BorderThickness="0,0,0,1">
+                                     <Border Grid.Row="0"
+                                             Padding="10,6"
+                                             Background="{DynamicResource WinHeaderBrush}"
+                                             BorderBrush="Transparent"
+                                             BorderThickness="0">
                                         <DockPanel LastChildFill="True">
                                             <Button DockPanel.Dock="Right"
                                                     Content="Refresh"

--- a/Client/analysis/Windows/InterfaceSettingsWindow.xaml
+++ b/Client/analysis/Windows/InterfaceSettingsWindow.xaml
@@ -99,6 +99,8 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="10"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="10"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <TextBlock Grid.Row="0"
@@ -136,6 +138,24 @@
                                        Grid.Column="2"
                                        Margin="12,0,0,0"
                                        Text="Default presentation used when the API view opens."
+                                       Foreground="{DynamicResource WinMutedTextBrush}"
+                                       TextWrapping="Wrap"
+                                       VerticalAlignment="Center"/>
+
+                            <TextBlock Grid.Row="4"
+                                       Grid.Column="0"
+                                       Text="Kernel hooks"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center"/>
+                            <CheckBox x:Name="KernelHooksArmedCheckBox"
+                                      Grid.Row="4"
+                                      Grid.Column="1"
+                                      Content="Hooks armed"
+                                      VerticalAlignment="Center"/>
+                            <TextBlock Grid.Row="4"
+                                       Grid.Column="2"
+                                       Margin="12,0,0,0"
+                                       Text="Controls runtime NTAPI hook arming for the active capture."
                                        Foreground="{DynamicResource WinMutedTextBrush}"
                                        TextWrapping="Wrap"
                                        VerticalAlignment="Center"/>

--- a/Client/analysis/Windows/LaunchParametersWindow.xaml
+++ b/Client/analysis/Windows/LaunchParametersWindow.xaml
@@ -2,10 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Launch Parameters"
-        Width="720"
-        Height="840"
-        MinWidth="720"
-        MinHeight="760"
+        Width="1540"
+        Height="880"
+        MinWidth="1380"
+        MinHeight="820"
         WindowStartupLocation="CenterOwner"
         WindowStyle="None"
         ResizeMode="CanResize"
@@ -14,7 +14,7 @@
         <Style x:Key="LaunchComboStyle" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
             <Setter Property="Background" Value="{DynamicResource WinHeaderBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource WinTextBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource WinBorderBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource WinSubtleBorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="6,2"/>
             <Setter Property="MinHeight" Value="26"/>
@@ -62,7 +62,7 @@
                                 <Border Margin="0,2,0,0"
                                         MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
                                         Background="{DynamicResource WinPanelBrush}"
-                                        BorderBrush="{DynamicResource WinBorderBrush}"
+                                        BorderBrush="{DynamicResource WinSubtleBorderBrush}"
                                         BorderThickness="1">
                                     <ScrollViewer MaxHeight="240"
                                                   CanContentScroll="True"
@@ -106,8 +106,8 @@
         </Style>
     </Window.Resources>
 
-    <Border BorderBrush="{DynamicResource WinBorderBrush}"
-            BorderThickness="1"
+    <Border BorderBrush="Transparent"
+            BorderThickness="0"
             Background="{DynamicResource WinBgBrush}">
         <Grid>
             <Grid.RowDefinitions>
@@ -116,7 +116,7 @@
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0"
-                  Background="{DynamicResource WinHeaderBrush}"
+                  Background="{DynamicResource WinBgBrush}"
                   MouseLeftButtonDown="Root_MouseLeftButtonDown">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -147,7 +147,7 @@
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0"
-                        BorderBrush="{DynamicResource PaneBorderBrush}"
+                        BorderBrush="{DynamicResource WinSubtleBorderBrush}"
                         BorderThickness="1"
                         Background="{DynamicResource WinPanelBrush}"
                         Padding="10,8">
@@ -164,14 +164,26 @@
                     </StackPanel>
                 </Border>
 
-                <ScrollViewer Grid.Row="1"
-                              Margin="0,14,0,0"
-                              VerticalScrollBarVisibility="Auto">
-                    <StackPanel>
-                        <Border BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                                BorderThickness="1"
-                                Background="{DynamicResource WinPanelBrush}"
-                                Padding="10,10">
+                <Grid Grid.Row="1"
+                      Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="390"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="540"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Grid.Column="0"
+                            Grid.Row="0"
+                            Grid.RowSpan="2"
+                            Margin="0,0,12,0"
+                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
+                            BorderThickness="1"
+                            Background="{DynamicResource WinPanelBrush}"
+                            Padding="10,10">
                             <StackPanel>
                                 <TextBlock FontWeight="SemiBold"
                                            Text="Instrumentation"/>
@@ -242,12 +254,15 @@
                             </StackPanel>
                         </Border>
 
-                        <Border x:Name="LaunchPhaseOnePanel"
-                                Margin="0,12,0,0"
-                                BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                                BorderThickness="1"
-                                Background="{DynamicResource WinPanelBrush}"
-                                Padding="10,10">
+                    <Border x:Name="LaunchPhaseOnePanel"
+                            Grid.Column="1"
+                            Grid.Row="0"
+                            Grid.RowSpan="2"
+                            Margin="0,0,12,0"
+                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
+                            BorderThickness="1"
+                            Background="{DynamicResource WinPanelBrush}"
+                            Padding="10,10">
                             <StackPanel>
                                 <TextBlock FontWeight="SemiBold"
                                            Text="Phase 1 Launch Context"/>
@@ -258,28 +273,26 @@
 
                                 <Grid Margin="0,10,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
                                                Text="Working directory"/>
-                                    <TextBox x:Name="WorkingDirectoryTextBox"
-                                             Grid.Column="1"
-                                             MinWidth="240"
-                                             HorizontalAlignment="Stretch"/>
+                                     <TextBox x:Name="WorkingDirectoryTextBox"
+                                              Grid.Column="1"
+                                              HorizontalAlignment="Stretch"/>
                                 </Grid>
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
                                                Text="Arguments"/>
-                                    <TextBox x:Name="CommandLineArgumentsTextBox"
-                                             Grid.Column="1"
-                                             MinWidth="240"
-                                             HorizontalAlignment="Stretch"
+                                     <TextBox x:Name="CommandLineArgumentsTextBox"
+                                              Grid.Column="1"
+                                              HorizontalAlignment="Stretch"
                                              FontFamily="{DynamicResource AppMonoFontFamily}"
                                              ToolTip="Arguments passed after the executable path. Preserve your own quoting, for example: --profile &quot;lab one&quot;"/>
                                 </Grid>
@@ -287,17 +300,16 @@
                                 <Grid x:Name="TargetPdbPathPanel"
                                       Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="80"/>
                                         <ColumnDefinition Width="72"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
                                                Text="Target PDB"/>
-                                    <TextBox x:Name="TargetPdbPathTextBox"
-                                             Grid.Column="1"
-                                             MinWidth="240"
-                                             HorizontalAlignment="Stretch"
+                                     <TextBox x:Name="TargetPdbPathTextBox"
+                                              Grid.Column="1"
+                                              HorizontalAlignment="Stretch"
                                              FontFamily="{DynamicResource AppMonoFontFamily}"/>
                                     <Button Grid.Column="2"
                                             Margin="8,0,0,0"
@@ -313,7 +325,7 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Top"
@@ -321,9 +333,9 @@
                                                Text="Environment overrides"/>
                                     <StackPanel Grid.Column="1">
                                         <TextBox x:Name="EnvironmentOverridesTextBox"
-                                                 AcceptsReturn="True"
-                                                 Height="110"
-                                                 VerticalScrollBarVisibility="Auto"
+                                                  AcceptsReturn="True"
+                                                  Height="118"
+                                                  VerticalScrollBarVisibility="Disabled"
                                                  TextWrapping="NoWrap"
                                                  FontFamily="{DynamicResource AppMonoFontFamily}"/>
                                         <TextBlock Margin="0,4,0,0"
@@ -338,10 +350,10 @@
 
                                 <Grid Margin="0,10,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="90"/>
-                                        <ColumnDefinition Width="150"/>
+                                        <ColumnDefinition Width="132"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
                                                Text="Spoof parent PID"/>
@@ -362,9 +374,9 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -393,7 +405,7 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="140"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -415,8 +427,10 @@
                             </StackPanel>
                         </Border>
 
-                        <Border Margin="0,12,0,0"
-                                BorderBrush="{DynamicResource WinSubtleBorderBrush}"
+                    <StackPanel Grid.Column="2"
+                                Grid.Row="0"
+                                Grid.RowSpan="2">
+                        <Border BorderBrush="{DynamicResource WinSubtleBorderBrush}"
                                 BorderThickness="1"
                                 Background="{DynamicResource WinPanelBrush}"
                                 Padding="10,10">
@@ -475,9 +489,9 @@
 
                                 <Grid Margin="0,10,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -507,9 +521,9 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -528,7 +542,7 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -540,9 +554,9 @@
 
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="170"/>
+                                        <ColumnDefinition Width="110"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center"
@@ -575,7 +589,7 @@
                                        Text="Attaching to a running process cannot use launch-only controls. Those options are disabled automatically outside of launch mode."/>
                         </Border>
                     </StackPanel>
-                </ScrollViewer>
+                </Grid>
 
                 <DockPanel Grid.Row="2"
                            Margin="0,14,0,0"

--- a/Client/analysis/Windows/LoadingWindow.xaml
+++ b/Client/analysis/Windows/LoadingWindow.xaml
@@ -14,8 +14,8 @@
         <Style x:Key="LoadingProgressBarStyle" TargetType="ProgressBar" BasedOn="{StaticResource {x:Type ProgressBar}}">
             <Setter Property="Background" Value="#FF101513"/>
             <Setter Property="Foreground" Value="#FF6FD3A8"/>
-            <Setter Property="BorderBrush" Value="#FF29443C"/>
-            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
         </Style>
     </Window.Resources>
 
@@ -67,8 +67,8 @@
             <Border Grid.Row="3"
                     Margin="0,8,0,0"
                     Padding="8,6"
-                    BorderThickness="1"
-                    BorderBrush="{DynamicResource WinSubtleBorderBrush}"
+                    BorderThickness="0"
+                    BorderBrush="Transparent"
                     Background="{DynamicResource WinPanelBrush}">
                 <TextBlock x:Name="StepsBlock"
                            FontFamily="{DynamicResource AppMonoFontFamily}"

--- a/Client/analysis/Windows/ProcessPickerWindow.xaml
+++ b/Client/analysis/Windows/ProcessPickerWindow.xaml
@@ -19,19 +19,33 @@
             <Setter Property="Padding" Value="8,4"/>
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
             <Setter Property="Foreground" Value="{DynamicResource WinTextBrush}"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="Transparent"/>
-                    <Setter Property="BorderBrush" Value="Transparent"/>
-                </Trigger>
-                <Trigger Property="IsPressed" Value="True">
-                    <Setter Property="Background" Value="Transparent"/>
-                    <Setter Property="BorderBrush" Value="Transparent"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.55"/>
-                </Trigger>
-            </Style.Triggers>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              TextElement.Foreground="{TemplateBinding Foreground}"
+                                              Margin="{TemplateBinding Padding}"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#FFF4F4F4"/>
+                                <Setter Property="Foreground" Value="#FF111111"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter Property="Background" Value="#FFE3E3E3"/>
+                                <Setter Property="Foreground" Value="#FF111111"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.55"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
 
         <Style x:Key="ProcessRowStyle"
@@ -74,7 +88,8 @@
                TargetType="ComboBox">
             <Setter Property="Background" Value="{DynamicResource WinPanelBrush}"/>
             <Setter Property="Foreground" Value="{DynamicResource WinTextBrush}"/>
-            <Setter Property="BorderBrush" Value="{DynamicResource WinBorderBrush}"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Padding" Value="6,2"/>
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
             <Setter Property="SnapsToDevicePixels" Value="True"/>
@@ -86,7 +101,7 @@
                                           Style="{DynamicResource PickerComboToggleStyle}"
                                           Background="{TemplateBinding Background}"
                                           BorderBrush="{TemplateBinding BorderBrush}"
-                                          BorderThickness="1"
+                                          BorderThickness="{TemplateBinding BorderThickness}"
                                           Focusable="False"
                                           IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                           ClickMode="Press">
@@ -118,9 +133,9 @@
                                    Focusable="False"
                                    IsOpen="{TemplateBinding IsDropDownOpen}"
                                    PopupAnimation="Fade">
-                                <Border Background="{DynamicResource WinPanelBrush}"
-                                        BorderBrush="{DynamicResource WinBorderBrush}"
-                                        BorderThickness="1"
+                                 <Border Background="{DynamicResource WinPanelBrush}"
+                                         BorderBrush="Transparent"
+                                         BorderThickness="0"
                                         SnapsToDevicePixels="True"
                                         MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}">
                                     <ScrollViewer CanContentScroll="True"
@@ -200,6 +215,12 @@
                    Margin="2,0,0,8"
                    LastChildFill="False"
                    MouseLeftButtonDown="Root_MouseLeftButtonDown">
+            <Button DockPanel.Dock="Right"
+                    Style="{DynamicResource SecondaryWindowTitleGlyphButtonStyle}"
+                    Content="&#xE8BB;"
+                    Tag="Close"
+                    ToolTip="Close"
+                    Click="Close_Click"/>
             <TextBlock Text="Display entries matching these conditions:"
                        FontWeight="SemiBold"
                        VerticalAlignment="Center"/>
@@ -220,9 +241,24 @@
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource WinMutedTextBrush}"
                        Margin="0,0,8,0"/>
-            <TextBox Grid.Column="1"
-                     x:Name="QuickSearchBox"
-                     TextChanged="QuickSearchBox_TextChanged"/>
+            <Grid Grid.Column="1">
+                <TextBox x:Name="QuickSearchBox"
+                         Padding="8,3,28,3"
+                         BorderBrush="{DynamicResource WinSubtleBorderBrush}"
+                         TextChanged="QuickSearchBox_TextChanged"/>
+                <Button x:Name="ClearQuickSearchButton"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Stretch"
+                        Width="24"
+                        MinWidth="24"
+                        Margin="0"
+                        Padding="0"
+                        Content="x"
+                        FontSize="11"
+                        Style="{DynamicResource PickerFlatButtonStyle}"
+                        ToolTip="Clear search"
+                        Click="ClearQuickSearch_Click"/>
+            </Grid>
 
             <TextBlock Grid.Column="3"
                        Text="Refresh:"

--- a/Client/analysis/Windows/ProcessPickerWindow.xaml.cs
+++ b/Client/analysis/Windows/ProcessPickerWindow.xaml.cs
@@ -137,6 +137,21 @@ namespace BlackbirdInterface
             WindowChromeBehavior.HandleRootDragMove(this, e);
         }
 
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            _ = sender;
+            _ = e;
+            try
+            {
+                DialogResult = false;
+            }
+            catch (InvalidOperationException)
+            {
+                // The selector can be hosted non-modally during diagnostics; closing still means cancel.
+            }
+            Close();
+        }
+
         public void PrimeForFirstShow()
         {
             EnsureInitialListPrepared();
@@ -167,6 +182,19 @@ namespace BlackbirdInterface
         private void Refresh_Click(object sender, RoutedEventArgs e) => RefreshList();
 
         private void QuickSearchBox_TextChanged(object sender, TextChangedEventArgs e) => ApplyFilter();
+
+        private void ClearQuickSearch_Click(object sender, RoutedEventArgs e)
+        {
+            _ = sender;
+            _ = e;
+            if (QuickSearchBox == null)
+            {
+                return;
+            }
+
+            QuickSearchBox.Text = string.Empty;
+            QuickSearchBox.Focus();
+        }
 
         private void FilterValueBox_KeyDown(object sender, KeyEventArgs e)
         {

--- a/Client/analysis/Windows/StartupWelcomeWindow.xaml
+++ b/Client/analysis/Windows/StartupWelcomeWindow.xaml
@@ -2,9 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title=""
-        Height="520"
+        Height="360"
         Width="620"
-        MinHeight="520"
+        MinHeight="360"
         MinWidth="620"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None"
@@ -20,8 +20,8 @@
 
         <Border Grid.Row="0"
                 Background="{DynamicResource WinHeaderBrush}"
-                BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                BorderThickness="0,0,0,1"
+                BorderBrush="Transparent"
+                BorderThickness="0"
                 Padding="14,10">
             <Grid>
             <Grid.ColumnDefinitions>
@@ -136,7 +136,8 @@
                     Margin="0,8,0,0"
                     BorderBrush="{DynamicResource WinSubtleBorderBrush}"
                     BorderThickness="0,1,0,0"
-                    Padding="0,8,0,0">
+                    Padding="0,8,0,0"
+                    Visibility="Collapsed">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
@@ -175,57 +176,6 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Row="4"
-                    Margin="0,8,0,0"
-                    Padding="10,8"
-                    BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                    BorderThickness="1"
-                    Background="{DynamicResource WinPanelBrush}">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1.2*"/>
-                        <ColumnDefinition Width="10"/>
-                        <ColumnDefinition Width="1*"/>
-                        <ColumnDefinition Width="10"/>
-                        <ColumnDefinition Width="1*"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Text="Rules Intel"
-                                   FontWeight="SemiBold"/>
-                        <TextBlock Margin="0,4,0,0"
-                                   Foreground="{DynamicResource WinMutedTextBrush}"
-                                   TextWrapping="Wrap"
-                                   Text="Local packs are available at startup and can be enabled before launch."/>
-                    </StackPanel>
-                    <Border Grid.Column="2"
-                            Padding="8,6"
-                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                            BorderThickness="1"
-                            Background="{DynamicResource WinHeaderBrush}">
-                        <StackPanel>
-                            <TextBlock Text="YARA"
-                                       FontWeight="SemiBold"/>
-                            <TextBlock Margin="0,2,0,0"
-                                       Foreground="{DynamicResource WinMutedTextBrush}"
-                                       Text="File and memory rule hits"/>
-                        </StackPanel>
-                    </Border>
-                    <Border Grid.Column="4"
-                            Padding="8,6"
-                            BorderBrush="{DynamicResource WinSubtleBorderBrush}"
-                            BorderThickness="1"
-                            Background="{DynamicResource WinHeaderBrush}">
-                        <StackPanel>
-                            <TextBlock Text="MITRE / SIGMA"
-                                       FontWeight="SemiBold"/>
-                            <TextBlock Margin="0,2,0,0"
-                                       Foreground="{DynamicResource WinMutedTextBrush}"
-                                       Text="Technique mapping and rule attribution"/>
-                        </StackPanel>
-                    </Border>
-                </Grid>
-            </Border>
-
             <TextBlock x:Name="RuntimeConfigNoteBlock"
                        Grid.Row="5"
                        Margin="0,8,0,0"
@@ -241,7 +191,7 @@
                     Content="Launch"
                     Height="34"
                     Background="{DynamicResource WinAccentBrush}"
-                    BorderBrush="{DynamicResource InputHoverBorderBrush}"
+                    BorderBrush="Transparent"
                     Foreground="{DynamicResource WinTextBrush}"
                     Click="Launch_Click"/>
             <Button Margin="0,0,8,0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-© 2026 TITAN Softwork Solutions / 8damon
+© 2026 RYFTENIUS / 8damon
 
 Licensed under the PolyForm Noncommercial 1.0.0 license with the
 Blackbird Defensive Use Addendum below.
@@ -8,7 +8,7 @@ authorized, defensive security purposes. Commercial use requires prior written
 permission. Any use outside the defensive scope below is not a permitted purpose
 under this license.
 
-Required Notice: © 2026 TITAN Softwork Solutions / 8damon
+Required Notice: © 2026 RYFTENIUS / 8damon
 
 # Blackbird Defensive Use Addendum
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <p align="center"><b>A powerful, instrumentable, real-time malware analysis platform, software reverse-engineering suite & IDS.</b></p>
 
 <p align="center">
-  <a href="https://titansoftwork.com/capability/blackbird/download/">
+  <a href="https://ryftenius.com/capability/blackbird/download/">
     <img src="https://img.shields.io/badge/Download-3C8D40?style=for-the-badge&logo=microsoft&logoColor=white" />
   </a>
-  <a href="https://titansoftwork.com/blackbird">
+  <a href="https://ryftenius.com/blackbird">
     <img src="https://img.shields.io/badge/Website-0A0A0A?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   <a href="https://github.com/users/8damon/projects/3/views/1">
@@ -19,10 +19,10 @@
 </p>
 
 <p align="center">
-  <img src="https://titansoftwork.com/content/capabilities/blackbird/MAIN_INTERFACE.png" width="980" alt="Blackbird main interface" />
+  <img src="https://ryftenius.com/content/capabilities/blackbird/MAIN_INTERFACE.png" width="980" alt="Blackbird main interface" />
 </p>
 <p align="center">
-  <img src="https://titansoftwork.com/content/capabilities/blackbird/MAIN_ALT.png" width="980" alt="Blackbird main interface" />
+  <img src="https://ryftenius.com/content/capabilities/blackbird/MAIN_ALT.png" width="980" alt="Blackbird main interface" />
 </p>
 
 ## REQUIREMENTS
@@ -63,7 +63,7 @@ Please use [this](https://github.com/users/8damon/projects/3) project board to o
 The public local-stack introduction, installation, architecture, security notes,
 and UI manual are provided here:
 
-- [Blackbird Docs](https://docs.titansoftwork.com/blackbird/)
+- [Blackbird Docs](https://docs.ryftenius.com/blackbird/)
 
 Session archives are stored as `.bkcap` (SQLite + LZ4). Detections can be exported as SIEM JSON Lines, Splunk HEC JSON, Elastic ECS NDJSON, CEF, or CSV. Detection reference scenarios are in `DetectionExamples.exe`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@
 
 We take security seriously and maintain a formal threat model (STRIDE-based) and an adapted Microsoft SDL process.
 
-- [Threat Model (STRIDE per component, trust boundaries, residual risks)](https://docs.titansoftwork.com/blackbird/#security/threat-model)
-- [Secure Development Lifecycle (SDL) assessment and action items](https://docs.titansoftwork.com/blackbird/#security/sdl)
+- [Threat Model (STRIDE per component, trust boundaries, residual risks)](https://docs.ryftenius.com/blackbird/#security/threat-model)
+- [Secure Development Lifecycle (SDL) assessment and action items](https://docs.ryftenius.com/blackbird/#security/sdl)
 
 ## Supported Versions
 
@@ -20,7 +20,7 @@ See the [Releases page](https://github.com/8damon/blackbird/releases) for versio
 If you discover a potential security vulnerability in Blackbird (kernel driver, usermode components, IPC, operator protocol, or deployment model), please report it **privately** so we can investigate and coordinate disclosure.
 
 **Preferred reporting method:**  
-Email us at **[security@titansoftwork.com](mailto:security@titansoftwork.com)**.
+Email us at **[security@ryftenius.com](mailto:security@ryftenius.com)**.
 
 Please include as much of the following as possible:
 
@@ -28,7 +28,7 @@ Please include as much of the following as possible:
 - Affected component(s) and version(s)
 - Steps to reproduce
 - Any proof-of-concept or logs (avoid sending full exploits in the initial email if possible)
-- Reference to relevant parts of the [threat model](https://docs.titansoftwork.com/blackbird/#security/threat-model) or [SDL](https://docs.titansoftwork.com/blackbird/#security/sdl) if applicable
+- Reference to relevant parts of the [threat model](https://docs.ryftenius.com/blackbird/#security/threat-model) or [SDL](https://docs.ryftenius.com/blackbird/#security/sdl) if applicable
 
 We also support **GitHub Private Vulnerability Reporting** (recommended for researchers who prefer the GitHub interface). This creates a private draft security advisory that only repository maintainers can see.
 

--- a/VCXProj/Blackbird.Interface.rc
+++ b/VCXProj/Blackbird.Interface.rc
@@ -11,7 +11,7 @@
 #endif
     FILEOS 0x00040004L FILETYPE 0x1L FILESUBTYPE 0x0L BEGIN BLOCK "StringFileInfo" BEGIN BLOCK "040904B0" BEGIN VALUE
                                                                   "CompanyName",
-    "TITAN Softwork Solutions" VALUE "FileDescription", "Blackbird Community analyst interface" VALUE "FileVersion",
+    "RYFTENIUS" VALUE "FileDescription", "Blackbird Community analyst interface" VALUE "FileVersion",
     "2.0.0.0" VALUE "InternalName", "BlackbirdInterface" VALUE "OriginalFilename",
     "BlackbirdInterface.exe" VALUE "ProductName", "Blackbird Community" VALUE "ProductVersion",
     "2.0.0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0409, 1200 END END

--- a/VCXProj/Blackbird.Runner.rc
+++ b/VCXProj/Blackbird.Runner.rc
@@ -10,7 +10,7 @@
 #endif
     FILEOS 0x00040004L FILETYPE 0x1L FILESUBTYPE 0x0L BEGIN BLOCK "StringFileInfo" BEGIN BLOCK "040904B0" BEGIN VALUE
                                                                   "CompanyName",
-    "TITAN Softwork Solutions" VALUE "FileDescription", "Blackbird Community capture runner" VALUE "FileVersion",
+    "RYFTENIUS" VALUE "FileDescription", "Blackbird Community capture runner" VALUE "FileVersion",
     "2.0.0.0" VALUE "InternalName", "BlackbirdRunner" VALUE "OriginalFilename",
     "BlackbirdRunner.exe" VALUE "ProductName", "Blackbird Community" VALUE "ProductVersion",
     "2.0.0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0409, 1200 END END

--- a/VCXProj/Blackbird.UserMode.Common.props
+++ b/VCXProj/Blackbird.UserMode.Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="BlackbirdUserModeIdentity">
-    <BlackbirdCompanyName Condition="'$(BlackbirdCompanyName)'==''">TITAN Softwork Solutions</BlackbirdCompanyName>
+    <BlackbirdCompanyName Condition="'$(BlackbirdCompanyName)'==''">RYFTENIUS</BlackbirdCompanyName>
     <BlackbirdProductName Condition="'$(BlackbirdProductName)'==''">Blackbird Community</BlackbirdProductName>
     <BlackbirdFileDescription Condition="'$(BlackbirdFileDescription)'==''">Blackbird Community user-mode component</BlackbirdFileDescription>
     <BlackbirdInternalName Condition="'$(BlackbirdInternalName)'==''">Blackbird</BlackbirdInternalName>
@@ -11,11 +11,11 @@
     <BlackbirdManifestPath>$(IntDir)$(TargetName).Blackbird.UserMode.manifest</BlackbirdManifestPath>
     <BlackbirdVersionRcPath>$(MSBuildThisFileDirectory)Blackbird.Version.rc</BlackbirdVersionRcPath>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BK_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">$(MSBuildThisFileDirectory)..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">$(MSBuildThisFileDirectory)..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BK_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignCommand>"$(BlackbirdSignToolPath)" sign /fd SHA256 /s "$(BlackbirdSignStoreName)" /n "$(BlackbirdSignSubjectName)" "$(TargetPath)"</BlackbirdSignCommand>
     <BlackbirdSignCommand Condition="'$(BlackbirdSignThumbprint)'!=''">"$(BlackbirdSignToolPath)" sign /fd SHA256 /s "$(BlackbirdSignStoreName)" /sha1 "$(BlackbirdSignThumbprint)" "$(TargetPath)"</BlackbirdSignCommand>

--- a/VCXProj/Blackbird.Version.rc
+++ b/VCXProj/Blackbird.Version.rc
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef BK_COMPANY_NAME
-#define BK_COMPANY_NAME "TITAN Softwork Solutions"
+#define BK_COMPANY_NAME "RYFTENIUS"
 #endif
 
 #ifndef BK_INTERNAL_NAME

--- a/VCXProj/Blackbird.vcxproj
+++ b/VCXProj/Blackbird.vcxproj
@@ -92,7 +92,7 @@
   <PropertyGroup>
     <SignMode>TestSign</SignMode>
     <CertificateStoreName>My</CertificateStoreName>
-    <SubjectName>TITAN Softwork Solutions</SubjectName>
+    <SubjectName>RYFTENIUS</SubjectName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/VCXProj/BlackbirdInterface.csproj
+++ b/VCXProj/BlackbirdInterface.csproj
@@ -13,12 +13,12 @@
     <AssemblyTitle>Blackbird Community analyst interface</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community analyst interface</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <InformationalVersion>2.0.0</InformationalVersion>
-    <Copyright>Copyright (c) TITAN Softwork Solutions</Copyright>
+    <Copyright>Copyright (c) RYFTENIUS</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -32,11 +32,11 @@
     <BlackbirdWin32ResourceOutput>..\x64\obj\BlackbirdInterface\$(Configuration)\BlackbirdInterface.res</BlackbirdWin32ResourceOutput>
     <Win32Resource>$(BlackbirdWin32ResourceOutput)</Win32Resource>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BLACKBIRD_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BLACKBIRD_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignBuildCommand>&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /n &quot;$(BlackbirdSignSubjectName)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>
     <BlackbirdSignBuildCommand Condition="'$(BlackbirdSignThumbprint)' != ''">&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /sha1 &quot;$(BlackbirdSignThumbprint)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>

--- a/VCXProj/BlackbirdOperator.csproj
+++ b/VCXProj/BlackbirdOperator.csproj
@@ -11,7 +11,7 @@
     <AssemblyTitle>Blackbird Community operator support library</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community operator support library</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>

--- a/VCXProj/BlackbirdRunner.csproj
+++ b/VCXProj/BlackbirdRunner.csproj
@@ -10,12 +10,12 @@
     <AssemblyTitle>Blackbird Community capture runner</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community capture runner</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <InformationalVersion>2.0.0</InformationalVersion>
-    <Copyright>Copyright (c) TITAN Softwork Solutions</Copyright>
+    <Copyright>Copyright (c) RYFTENIUS</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -29,11 +29,11 @@
     <BlackbirdWin32ResourceOutput>..\x64\obj\BlackbirdRunner\$(Configuration)\BlackbirdRunner.res</BlackbirdWin32ResourceOutput>
     <Win32Resource>$(BlackbirdWin32ResourceOutput)</Win32Resource>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BLACKBIRD_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BLACKBIRD_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignBuildCommand>&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /n &quot;$(BlackbirdSignSubjectName)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>
     <BlackbirdSignBuildCommand Condition="'$(BlackbirdSignThumbprint)' != ''">&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /sha1 &quot;$(BlackbirdSignThumbprint)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>


### PR DESCRIPTION
## Summary
- fixes global button hover/pressed foregrounds so light hover states keep dark readable text
- softens window and diagnostics borders without pulling in private panes or server UI
- widens and reflows launch parameters to reduce clipping and vertical scrolling
- adds close/clear affordances to the process picker search flow
- removes the unused startup rule-intel block from the welcome window

Fixes #33
Refs #3

## Validation
- `git diff --check`
- denied-string scan for Enterprise-only terms in staged additions
- `dotnet build VCXProj/BlackbirdInterface.csproj -c Debug`
- started `BlackbirdInterface.exe` from the Debug output and stopped it after a 5-second startup smoke test