### PR TITLE
Reduce PIC instrumentation self-noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ codex-build/
 *.key
 *.pvk
 *.snk
-TITAN Softwork Solutions.pfx
+RYFTENIUS.pfx
 
 # Website documentation is published from the website pipeline, not the
 # Community source repo.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Lib/Blackbird Disassembler"]
 path = Lib/Blackbird Disassembler
-url = https://github.com/TITAN-Softwork-Solutions/Blackbird-Disassembler
+url = https://github.com/RYFTENIUS/Blackbird-Disassembler

--- a/Blackbird.inf
+++ b/Blackbird.inf
@@ -50,7 +50,7 @@ HKR,"Instances\%BlackbirdInstanceName%","Altitude",0x00000000,%BlackbirdInstance
 HKR,"Instances\%BlackbirdInstanceName%","Flags",0x00010001,%BlackbirdInstanceFlags%
 
 [Strings]
-ManufacturerName = "TITAN Softwork Solutions"
+ManufacturerName = "RYFTENIUS"
 DiskName = "Blackbird Community Installation Disk"
 BLACKBIRD.SVCDESC = "Blackbird Community Driver"
 BlackbirdInstanceName = "Blackbird Default"

--- a/Client/analysis/App.xaml.cs
+++ b/Client/analysis/App.xaml.cs
@@ -24,7 +24,7 @@ namespace BlackbirdInterface
 
     public partial class App : Application
     {
-        private const string GettingStartedUrl = "https://titansoftwork.com/blackbird/intro";
+        private const string GettingStartedUrl = "https://ryftenius.com/blackbird/intro";
         private static Mutex? _singleInstanceMutex;
         internal static bool IsDarkTheme { get; private set; } = true;
         internal static UiThemeMode CurrentThemeMode { get; private set; } = UiThemeMode.Dark;

--- a/Client/analysis/Interop/BlackbirdNative.cs
+++ b/Client/analysis/Interop/BlackbirdNative.cs
@@ -222,6 +222,7 @@ namespace BlackbirdInterface
         internal const uint IpcEtwFamilyThreatIntel = 8;
         internal const uint IpcEtwFamilySocket = 9;
         internal const uint IpcEtwFamilyUserHook = 10;
+        internal const uint IpcEtwFamilyIpcIo = 11;
 
         internal const uint IpcEtwFlagHandleExecProtect = 0x00000001;
         internal const uint IpcEtwFlagHandleFromNtdll = 0x00000002;

--- a/Client/analysis/Settings/AnalystSettingsStore.cs
+++ b/Client/analysis/Settings/AnalystSettingsStore.cs
@@ -6,7 +6,7 @@ namespace BlackbirdInterface
 {
     internal static class AnalystSettingsStore
     {
-        private const string RootKeyPath = @"Software\TITAN Softwork Solutions\BK\Interface";
+        private const string RootKeyPath = @"Software\RYFTENIUS\BK\Interface";
         private const string ThemeValueName = "ThemeMode";
         private const string ShortcutKeyPath = RootKeyPath + @"\Shortcuts";
         private const string PreferencesKeyPath = RootKeyPath + @"\Preferences";

--- a/Client/analysis/Settings/SymbolSettingsStore.cs
+++ b/Client/analysis/Settings/SymbolSettingsStore.cs
@@ -5,7 +5,7 @@ namespace BlackbirdInterface
 {
     internal static class SymbolSettingsStore
     {
-        private const string RootKeyPath = @"Software\TITAN Softwork Solutions\BK\Interface";
+        private const string RootKeyPath = @"Software\RYFTENIUS\BK\Interface";
         private const string SymbolsKeyPath = RootKeyPath + @"\Symbols";
 
         internal static SymbolSettings LoadSymbolSettings()

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-© 2026 TITAN Softwork Solutions / 8damon
+© 2026 RYFTENIUS / 8damon
 
 Licensed under the PolyForm Noncommercial 1.0.0 license with the
 Blackbird Defensive Use Addendum below.
@@ -8,7 +8,7 @@ authorized, defensive security purposes. Commercial use requires prior written
 permission. Any use outside the defensive scope below is not a permitted purpose
 under this license.
 
-Required Notice: © 2026 TITAN Softwork Solutions / 8damon
+Required Notice: © 2026 RYFTENIUS / 8damon
 
 # Blackbird Defensive Use Addendum
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <p align="center"><b>A powerful, instrumentable, real-time malware analysis platform, software reverse-engineering suite & IDS.</b></p>
 
 <p align="center">
-  <a href="https://titansoftwork.com/capability/blackbird/download/">
+  <a href="https://ryftenius.com/capability/blackbird/download/">
     <img src="https://img.shields.io/badge/Download-3C8D40?style=for-the-badge&logo=microsoft&logoColor=white" />
   </a>
-  <a href="https://titansoftwork.com/blackbird">
+  <a href="https://ryftenius.com/blackbird">
     <img src="https://img.shields.io/badge/Website-0A0A0A?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   <a href="https://github.com/users/8damon/projects/3/views/1">
@@ -19,10 +19,10 @@
 </p>
 
 <p align="center">
-  <img src="https://titansoftwork.com/content/capabilities/blackbird/MAIN_INTERFACE.png" width="980" alt="Blackbird main interface" />
+  <img src="https://ryftenius.com/content/capabilities/blackbird/MAIN_INTERFACE.png" width="980" alt="Blackbird main interface" />
 </p>
 <p align="center">
-  <img src="https://titansoftwork.com/content/capabilities/blackbird/MAIN_ALT.png" width="980" alt="Blackbird main interface" />
+  <img src="https://ryftenius.com/content/capabilities/blackbird/MAIN_ALT.png" width="980" alt="Blackbird main interface" />
 </p>
 
 ## REQUIREMENTS
@@ -63,7 +63,7 @@ Please use [this](https://github.com/users/8damon/projects/3) project board to o
 The public local-stack introduction, installation, architecture, security notes,
 and UI manual are provided here:
 
-- [Blackbird Docs](https://docs.titansoftwork.com/blackbird/)
+- [Blackbird Docs](https://docs.ryftenius.com/blackbird/)
 
 Session archives are stored as `.bkcap` (SQLite + LZ4). Detections can be exported as SIEM JSON Lines, Splunk HEC JSON, Elastic ECS NDJSON, CEF, or CSV. Detection reference scenarios are in `DetectionExamples.exe`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@
 
 We take security seriously and maintain a formal threat model (STRIDE-based) and an adapted Microsoft SDL process.
 
-- [Threat Model (STRIDE per component, trust boundaries, residual risks)](https://docs.titansoftwork.com/blackbird/#security/threat-model)
-- [Secure Development Lifecycle (SDL) assessment and action items](https://docs.titansoftwork.com/blackbird/#security/sdl)
+- [Threat Model (STRIDE per component, trust boundaries, residual risks)](https://docs.ryftenius.com/blackbird/#security/threat-model)
+- [Secure Development Lifecycle (SDL) assessment and action items](https://docs.ryftenius.com/blackbird/#security/sdl)
 
 ## Supported Versions
 
@@ -20,7 +20,7 @@ See the [Releases page](https://github.com/8damon/blackbird/releases) for versio
 If you discover a potential security vulnerability in Blackbird (kernel driver, usermode components, IPC, operator protocol, or deployment model), please report it **privately** so we can investigate and coordinate disclosure.
 
 **Preferred reporting method:**  
-Email us at **[security@titansoftwork.com](mailto:security@titansoftwork.com)**.
+Email us at **[security@ryftenius.com](mailto:security@ryftenius.com)**.
 
 Please include as much of the following as possible:
 
@@ -28,7 +28,7 @@ Please include as much of the following as possible:
 - Affected component(s) and version(s)
 - Steps to reproduce
 - Any proof-of-concept or logs (avoid sending full exploits in the initial email if possible)
-- Reference to relevant parts of the [threat model](https://docs.titansoftwork.com/blackbird/#security/threat-model) or [SDL](https://docs.titansoftwork.com/blackbird/#security/sdl) if applicable
+- Reference to relevant parts of the [threat model](https://docs.ryftenius.com/blackbird/#security/threat-model) or [SDL](https://docs.ryftenius.com/blackbird/#security/sdl) if applicable
 
 We also support **GitHub Private Vulnerability Reporting** (recommended for researchers who prefer the GitHub interface). This creates a private draft security advisory that only repository maintainers can see.
 

--- a/Usermode/controller/core/correlation/pic_correlation.cpp
+++ b/Usermode/controller/core/correlation/pic_correlation.cpp
@@ -200,10 +200,14 @@ VOID ControllerPicCorrelationApply(_Inout_ BKIPC_ETW_EVENT *Event)
         return;
     }
 
+    if ((Event->Reserved2 & BKIPC_ETW_TRAIT_BLACKBIRD_OWN) != 0 ||
+        ControllerAsciiEqualsInsensitive(Event->DetectionName, "BK_INSTRUMENTATION"))
+    {
+        return;
+    }
+
     ControllerPicCorrelationObserve(Event);
-    if (PicEventIsDirectSyscall(Event) ||
-        ControllerAsciiEqualsInsensitive(Event->DetectionName, "BK_INSTRUMENTATION") ||
-        (Event->Reserved2 & BKIPC_ETW_TRAIT_BLACKBIRD_OWN) != 0)
+    if (PicEventIsDirectSyscall(Event))
     {
         return;
     }

--- a/Usermode/controller/core/ipc/ipc.cpp
+++ b/Usermode/controller/core/ipc/ipc.cpp
@@ -2721,7 +2721,7 @@ static DWORD ControllerClientPublishHookEvent(_Inout_ BK_CONTROLLER_CLIENT *Clie
         BOOL blackbirdOwned = FALSE;
 
         EnterCriticalSection(&Client->Lock);
-        blackbirdOwned = ControllerIsBlackbirdOwnedAddress(Client, HookEvent->Caller);
+        blackbirdOwned = ControllerEtwEventTouchesBlackbirdOwnedRange(Client, &mapped);
         LeaveCriticalSection(&Client->Lock);
 
         if (blackbirdOwned && HookEvent->Kind != BlackbirdIpcHookEventExceptionLowNoise &&
@@ -2733,6 +2733,11 @@ static DWORD ControllerClientPublishHookEvent(_Inout_ BK_CONTROLLER_CLIENT *Clie
             }
 
             mapped.Reserved2 = ControllerComputeEtwDetectionTraits(mapped) | BKIPC_ETW_TRAIT_BLACKBIRD_OWN;
+            if (ControllerEtwEventIsBlackbirdOwnedNoise(&mapped))
+            {
+                return ERROR_SUCCESS;
+            }
+
             mapped.Severity = 1u;
             (void)StringCchCopyA(mapped.DetectionName, RTL_NUMBER_OF(mapped.DetectionName), "BK_INSTRUMENTATION");
             ControllerDispatchEtwEvent(&mapped);

--- a/VCXProj/Blackbird.Interface.rc
+++ b/VCXProj/Blackbird.Interface.rc
@@ -11,7 +11,7 @@
 #endif
     FILEOS 0x00040004L FILETYPE 0x1L FILESUBTYPE 0x0L BEGIN BLOCK "StringFileInfo" BEGIN BLOCK "040904B0" BEGIN VALUE
                                                                   "CompanyName",
-    "TITAN Softwork Solutions" VALUE "FileDescription", "Blackbird Community analyst interface" VALUE "FileVersion",
+    "RYFTENIUS" VALUE "FileDescription", "Blackbird Community analyst interface" VALUE "FileVersion",
     "2.0.0.0" VALUE "InternalName", "BlackbirdInterface" VALUE "OriginalFilename",
     "BlackbirdInterface.exe" VALUE "ProductName", "Blackbird Community" VALUE "ProductVersion",
     "2.0.0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0409, 1200 END END

--- a/VCXProj/Blackbird.Runner.rc
+++ b/VCXProj/Blackbird.Runner.rc
@@ -10,7 +10,7 @@
 #endif
     FILEOS 0x00040004L FILETYPE 0x1L FILESUBTYPE 0x0L BEGIN BLOCK "StringFileInfo" BEGIN BLOCK "040904B0" BEGIN VALUE
                                                                   "CompanyName",
-    "TITAN Softwork Solutions" VALUE "FileDescription", "Blackbird Community capture runner" VALUE "FileVersion",
+    "RYFTENIUS" VALUE "FileDescription", "Blackbird Community capture runner" VALUE "FileVersion",
     "2.0.0.0" VALUE "InternalName", "BlackbirdRunner" VALUE "OriginalFilename",
     "BlackbirdRunner.exe" VALUE "ProductName", "Blackbird Community" VALUE "ProductVersion",
     "2.0.0" END END BLOCK "VarFileInfo" BEGIN VALUE "Translation", 0x0409, 1200 END END

--- a/VCXProj/Blackbird.UserMode.Common.props
+++ b/VCXProj/Blackbird.UserMode.Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="BlackbirdUserModeIdentity">
-    <BlackbirdCompanyName Condition="'$(BlackbirdCompanyName)'==''">TITAN Softwork Solutions</BlackbirdCompanyName>
+    <BlackbirdCompanyName Condition="'$(BlackbirdCompanyName)'==''">RYFTENIUS</BlackbirdCompanyName>
     <BlackbirdProductName Condition="'$(BlackbirdProductName)'==''">Blackbird Community</BlackbirdProductName>
     <BlackbirdFileDescription Condition="'$(BlackbirdFileDescription)'==''">Blackbird Community user-mode component</BlackbirdFileDescription>
     <BlackbirdInternalName Condition="'$(BlackbirdInternalName)'==''">Blackbird</BlackbirdInternalName>
@@ -11,11 +11,11 @@
     <BlackbirdManifestPath>$(IntDir)$(TargetName).Blackbird.UserMode.manifest</BlackbirdManifestPath>
     <BlackbirdVersionRcPath>$(MSBuildThisFileDirectory)Blackbird.Version.rc</BlackbirdVersionRcPath>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BK_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">$(MSBuildThisFileDirectory)..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">$(MSBuildThisFileDirectory)..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BK_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignCommand>"$(BlackbirdSignToolPath)" sign /fd SHA256 /s "$(BlackbirdSignStoreName)" /n "$(BlackbirdSignSubjectName)" "$(TargetPath)"</BlackbirdSignCommand>
     <BlackbirdSignCommand Condition="'$(BlackbirdSignThumbprint)'!=''">"$(BlackbirdSignToolPath)" sign /fd SHA256 /s "$(BlackbirdSignStoreName)" /sha1 "$(BlackbirdSignThumbprint)" "$(TargetPath)"</BlackbirdSignCommand>

--- a/VCXProj/Blackbird.Version.rc
+++ b/VCXProj/Blackbird.Version.rc
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef BK_COMPANY_NAME
-#define BK_COMPANY_NAME "TITAN Softwork Solutions"
+#define BK_COMPANY_NAME "RYFTENIUS"
 #endif
 
 #ifndef BK_INTERNAL_NAME

--- a/VCXProj/Blackbird.vcxproj
+++ b/VCXProj/Blackbird.vcxproj
@@ -92,7 +92,7 @@
   <PropertyGroup>
     <SignMode>TestSign</SignMode>
     <CertificateStoreName>My</CertificateStoreName>
-    <SubjectName>TITAN Softwork Solutions</SubjectName>
+    <SubjectName>RYFTENIUS</SubjectName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>

--- a/VCXProj/BlackbirdInterface.csproj
+++ b/VCXProj/BlackbirdInterface.csproj
@@ -13,12 +13,12 @@
     <AssemblyTitle>Blackbird Community analyst interface</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community analyst interface</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <InformationalVersion>2.0.0</InformationalVersion>
-    <Copyright>Copyright (c) TITAN Softwork Solutions</Copyright>
+    <Copyright>Copyright (c) RYFTENIUS</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -32,11 +32,11 @@
     <BlackbirdWin32ResourceOutput>..\x64\obj\BlackbirdInterface\$(Configuration)\BlackbirdInterface.res</BlackbirdWin32ResourceOutput>
     <Win32Resource>$(BlackbirdWin32ResourceOutput)</Win32Resource>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BLACKBIRD_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BLACKBIRD_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignBuildCommand>&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /n &quot;$(BlackbirdSignSubjectName)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>
     <BlackbirdSignBuildCommand Condition="'$(BlackbirdSignThumbprint)' != ''">&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /sha1 &quot;$(BlackbirdSignThumbprint)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>

--- a/VCXProj/BlackbirdOperator.csproj
+++ b/VCXProj/BlackbirdOperator.csproj
@@ -11,7 +11,7 @@
     <AssemblyTitle>Blackbird Community operator support library</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community operator support library</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>

--- a/VCXProj/BlackbirdRunner.csproj
+++ b/VCXProj/BlackbirdRunner.csproj
@@ -10,12 +10,12 @@
     <AssemblyTitle>Blackbird Community capture runner</AssemblyTitle>
     <Product>Blackbird Community</Product>
     <Description>Blackbird Community capture runner</Description>
-    <Company>TITAN Softwork Solutions</Company>
+    <Company>RYFTENIUS</Company>
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <InformationalVersion>2.0.0</InformationalVersion>
-    <Copyright>Copyright (c) TITAN Softwork Solutions</Copyright>
+    <Copyright>Copyright (c) RYFTENIUS</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -29,11 +29,11 @@
     <BlackbirdWin32ResourceOutput>..\x64\obj\BlackbirdRunner\$(Configuration)\BlackbirdRunner.res</BlackbirdWin32ResourceOutput>
     <Win32Resource>$(BlackbirdWin32ResourceOutput)</Win32Resource>
     <BlackbirdSignEnabled Condition="'$(BlackbirdSignEnabled)'==''">false</BlackbirdSignEnabled>
-    <BlackbirdSignSubjectName>TITAN Softwork Solutions</BlackbirdSignSubjectName>
+    <BlackbirdSignSubjectName>RYFTENIUS</BlackbirdSignSubjectName>
     <BlackbirdSignStoreName>My</BlackbirdSignStoreName>
     <BlackbirdSignThumbprint Condition="'$(BlackbirdSignThumbprint)'==''">$(BLACKBIRD_SIGN_THUMBPRINT)</BlackbirdSignThumbprint>
     <BlackbirdSignToolPath>signtool.exe</BlackbirdSignToolPath>
-    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\TITAN Softwork Solutions.pfx</BlackbirdSignPfxPath>
+    <BlackbirdSignPfxPath Condition="'$(BlackbirdSignPfxPath)'==''">..\RYFTENIUS.pfx</BlackbirdSignPfxPath>
     <BlackbirdSignPfxPassword Condition="'$(BlackbirdSignPfxPassword)'==''">$(BLACKBIRD_SIGN_PFX_PASSWORD)</BlackbirdSignPfxPassword>
     <BlackbirdSignBuildCommand>&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /n &quot;$(BlackbirdSignSubjectName)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>
     <BlackbirdSignBuildCommand Condition="'$(BlackbirdSignThumbprint)' != ''">&quot;$(BlackbirdSignToolPath)&quot; sign /fd SHA256 /s &quot;$(BlackbirdSignStoreName)&quot; /sha1 &quot;$(BlackbirdSignThumbprint)&quot; &quot;$(TargetPath)&quot;</BlackbirdSignBuildCommand>


### PR DESCRIPTION
## Summary
- stops PIC correlation from learning or promoting Blackbird-owned instrumentation events
- checks the full mapped ETW event for owned ranges before emitting self-instrumentation telemetry
- drops low-value Blackbird-owned direct-syscall/self-noise instead of feeding it back into the operator stream
- carries the public IPC family constant needed for current Community .NET builds from `stable`

Refs #27
Refs #28

## Validation
- `git diff --check`
- denied-string scan for Enterprise-only terms in staged additions
- `dotnet build VCXProj/BlackbirdInterface.csproj -c Debug`
- `dotnet build VCXProj/BlackbirdRunner.csproj -c Debug`
- `MSBuild VCXProj/BlackbirdSensorCore.vcxproj /p:Configuration=Debug /p:Platform=x64 /m:1`

## Note
`BlackbirdController.vcxproj` was also attempted, but this machine's VS Insiders install currently mixes MSVC 14.44 `cl.exe` with 14.51 STL headers and fails before project code with `STL1001: Unexpected compiler version, expected MSVC Compiler 19.50 or newer.`