### PR TITLE
Focus public network traffic pane

### DIFF
--- a/Client/analysis/Interop/BlackbirdNative.cs
+++ b/Client/analysis/Interop/BlackbirdNative.cs
@@ -222,6 +222,7 @@ namespace BlackbirdInterface
         internal const uint IpcEtwFamilyThreatIntel = 8;
         internal const uint IpcEtwFamilySocket = 9;
         internal const uint IpcEtwFamilyUserHook = 10;
+        internal const uint IpcEtwFamilyIpcIo = 11;
 
         internal const uint IpcEtwFlagHandleExecProtect = 0x00000001;
         internal const uint IpcEtwFlagHandleFromNtdll = 0x00000002;

--- a/Client/analysis/Panes/PerformancePane.xaml
+++ b/Client/analysis/Panes/PerformancePane.xaml
@@ -202,6 +202,7 @@
                                 <Button x:Name="NetworkViewSwitchButton"
                                         DockPanel.Dock="Right"
                                         Content="Peers"
+                                        Visibility="Collapsed"
                                         MinWidth="54"
                                         MinHeight="0"
                                         Height="18"


### PR DESCRIPTION
## Summary
- hides the redundant Peers toggle in the main performance network pane so Community keeps the traffic view focused
- carries the public IPC family constant needed for current Community .NET builds from `stable`
- intentionally does not import the private managed-network/endpoint-guard internals from Enterprise

Refs #30

## Validation
- `git diff --check`
- denied-string scan for Enterprise-only terms in staged additions
- `dotnet build VCXProj/BlackbirdInterface.csproj -c Debug`